### PR TITLE
update for Android Studio 2.3 and update DataBus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## Version 2.0.2
+- 依存する Gradle と Build Tools を Android Studio 2.3 対応バージョンに更新
+- DataBusをVersion 2.0.3に更新
+
 ## Version 2.0.1
 DataBusをVersion 2.0.2に更新
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ DataChannel の Android用の実装を提供します。
 ### gradle
 ```
 dependencies {
-	compile 'jp.co.dwango.cbb:data-channel:2.0.1'
+	compile 'jp.co.dwango.cbb:data-channel:2.0.2'
 }
 ```
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 24
+    compileSdkVersion 23
     buildToolsVersion '25.0.0'
     defaultConfig {
         applicationId "jp.co.dwango.cbb.dc.test"
         minSdkVersion 16
-        targetSdkVersion 24
+        targetSdkVersion 23
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -24,7 +24,7 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:24.2.1'
+    compile 'com.android.support:appcompat-v7:23.2.1'
     compile project(':data-channel')
     testCompile 'junit:junit:4.12'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    buildToolsVersion '25.0.0'
     defaultConfig {
         applicationId "jp.co.dwango.cbb.dc.test"
         minSdkVersion 16

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
     }
 }
 

--- a/data-channel/build.gradle
+++ b/data-channel/build.gradle
@@ -34,6 +34,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
+    //noinspection GradleCompatible
     compile 'com.android.support:appcompat-v7:23.2.1'
     compile 'jp.co.dwango.cbb:data-bus:2.0.3'
     testCompile 'junit:junit:4.12'

--- a/data-channel/build.gradle
+++ b/data-channel/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.novoda.bintray-release'
-def pomVersion = "2.0.1"
+def pomVersion = "2.0.2"
 
 buildscript {
     repositories {
@@ -13,7 +13,7 @@ buildscript {
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         minSdkVersion 16
@@ -35,7 +35,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.2.1'
-    compile 'jp.co.dwango.cbb:data-bus:2.0.2'
+    compile 'jp.co.dwango.cbb:data-bus:2.0.3'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.9.5'
     testCompile 'org.json:json:20140107'

--- a/data-channel/build.gradle
+++ b/data-channel/build.gradle
@@ -34,7 +34,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    //noinspection GradleCompatible
     compile 'com.android.support:appcompat-v7:23.2.1'
     compile 'jp.co.dwango.cbb:data-bus:2.0.3'
     testCompile 'junit:junit:4.12'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 28 10:00:20 PST 2015
+#Wed Mar 22 19:31:44 JST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
- 依存する Gradle と Build Tools を Android Studio 2.3 対応バージョンに更新
- DataBusをVersion 2.0.3に更新