### PR TITLE
support multi-thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+## Version 2.0.4
+性能改善 (不要な排他制御を排除)
+
 ## Version 2.0.3
 - マルチスレッド対応 
 - DataBusをVersion 2.1.0に更新

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version 2.0.3
 - マルチスレッド対応 
-- DataBusをVersion 2.0.5に更新
+- DataBusをVersion 2.1.0に更新
 
 ## Version 2.0.2
 - 依存する Gradle と Build Tools を Android Studio 2.3 対応バージョンに更新

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## Version 2.0.3
+- マルチスレッド対応 
+- DataBusをVersion 2.0.5に更新
+
 ## Version 2.0.2
 - 依存する Gradle と Build Tools を Android Studio 2.3 対応バージョンに更新
 - DataBusをVersion 2.0.3に更新

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ DataChannel の Android用の実装を提供します。
 ### gradle
 ```
 dependencies {
-	compile 'jp.co.dwango.cbb:data-channel:2.0.2'
+	compile 'jp.co.dwango.cbb:data-channel:2.0.3'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ DataChannel の Android用の実装を提供します。
 ### gradle
 ```
 dependencies {
-	compile 'jp.co.dwango.cbb:data-channel:2.0.3'
+	compile 'jp.co.dwango.cbb:data-channel:2.0.4'
 }
 ```
 

--- a/app/src/main/java/jp/co/dwango/cbb/dc/test/MainActivity.java
+++ b/app/src/main/java/jp/co/dwango/cbb/dc/test/MainActivity.java
@@ -21,8 +21,8 @@ import java.io.InputStreamReader;
 import jp.co.dwango.cbb.db.DataBus;
 import jp.co.dwango.cbb.db.WebViewDataBus;
 import jp.co.dwango.cbb.dc.DataChannel;
-import jp.co.dwango.cbb.dc.DataChannelHandler;
 import jp.co.dwango.cbb.dc.DataChannelCallback;
+import jp.co.dwango.cbb.dc.DataChannelHandler;
 import jp.co.dwango.cbb.dc.DataChannelResponseHandler;
 import jp.co.dwango.cbb.dc.ErrorType;
 
@@ -83,21 +83,19 @@ public class MainActivity extends AppCompatActivity {
 		v.setOnClickListener(new View.OnClickListener() {
 			@Override
 			public void onClick(View view) {
-				for (int i = 0; i < 10; i++) {
-					dataChannel.sendRequest("request from Java to JS", new DataChannelResponseHandler() {
-						@Override
-						public void onResponse(Object packet) {
-							String text = "received result from js: packet=" + packet;
-							Log.d("data-dataChannel-java", text);
-							Toast.makeText(MainActivity.this, text, Toast.LENGTH_SHORT).show();
-						}
+				dataChannel.sendRequest("request from Java to JS", new DataChannelResponseHandler() {
+					@Override
+					public void onResponse(Object packet) {
+						String text = "received result from js: packet=" + packet;
+						Log.d("data-dataChannel-java", text);
+						Toast.makeText(MainActivity.this, text, Toast.LENGTH_SHORT).show();
+					}
 
-						@Override
-						public void onError(ErrorType errorType) {
-							Log.d("data-dataChannel-java", "received error-result from js: errorType=" + errorType);
-						}
-					});
-				}
+					@Override
+					public void onError(ErrorType errorType) {
+						Log.d("data-dataChannel-java", "received error-result from js: errorType=" + errorType);
+					}
+				});
 			}
 		});
 

--- a/app/src/main/java/jp/co/dwango/cbb/dc/test/MainActivity.java
+++ b/app/src/main/java/jp/co/dwango/cbb/dc/test/MainActivity.java
@@ -83,19 +83,21 @@ public class MainActivity extends AppCompatActivity {
 		v.setOnClickListener(new View.OnClickListener() {
 			@Override
 			public void onClick(View view) {
-				dataChannel.sendRequest("request from Java to JS", new DataChannelResponseHandler() {
-					@Override
-					public void onResponse(Object packet) {
-						String text = "received result from js: packet=" + packet;
-						Log.d("data-dataChannel-java", text);
-						Toast.makeText(MainActivity.this, text, Toast.LENGTH_SHORT).show();
-					}
+				for (int i = 0; i < 10; i++) {
+					dataChannel.sendRequest("request from Java to JS", new DataChannelResponseHandler() {
+						@Override
+						public void onResponse(Object packet) {
+							String text = "received result from js: packet=" + packet;
+							Log.d("data-dataChannel-java", text);
+							Toast.makeText(MainActivity.this, text, Toast.LENGTH_SHORT).show();
+						}
 
-					@Override
-					public void onError(ErrorType errorType) {
-						Log.d("data-dataChannel-java", "received error-result from js: errorType=" + errorType);
-					}
-				});
+						@Override
+						public void onError(ErrorType errorType) {
+							Log.d("data-dataChannel-java", "received error-result from js: errorType=" + errorType);
+						}
+					});
+				}
 			}
 		});
 

--- a/data-channel/build.gradle
+++ b/data-channel/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.novoda.bintray-release'
-def pomVersion = "2.0.2"
+def pomVersion = "2.0.3"
 
 buildscript {
     repositories {
@@ -35,7 +35,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.2.1'
-    compile 'jp.co.dwango.cbb:data-bus:2.0.3'
+    compile 'jp.co.dwango.cbb:data-bus:2.0.5'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.9.5'
     testCompile 'org.json:json:20140107'

--- a/data-channel/build.gradle
+++ b/data-channel/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.novoda.bintray-release'
-def pomVersion = "2.0.3"
+def pomVersion = "2.0.4"
 
 buildscript {
     repositories {

--- a/data-channel/build.gradle
+++ b/data-channel/build.gradle
@@ -35,7 +35,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.2.1'
-    compile 'jp.co.dwango.cbb:data-bus:2.0.5'
+    compile 'jp.co.dwango.cbb:data-bus:2.1.0'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.9.5'
     testCompile 'org.json:json:20140107'

--- a/data-channel/src/main/java/jp/co/dwango/cbb/dc/DataChannelWaitingResponseTable.java
+++ b/data-channel/src/main/java/jp/co/dwango/cbb/dc/DataChannelWaitingResponseTable.java
@@ -8,33 +8,26 @@ import java.util.concurrent.ConcurrentHashMap;
 
 class DataChannelWaitingResponseTable {
 	private final Map<String, DataChannelResponseHandler> table = new ConcurrentHashMap<String, DataChannelResponseHandler>();
-	private final Object locker = new Object();
 
 	DataChannelResponseHandler get(RequestTag tag) {
-		synchronized (locker) {
-			Set<String> keys = table.keySet();
-			String tagString = tag.toString();
-			for (String key : keys) {
-				if (key.equals(tagString)) {
-					return table.remove(key);
-				}
+		Set<String> keys = table.keySet();
+		String tagString = tag.toString();
+		for (String key : keys) {
+			if (key.equals(tagString)) {
+				return table.remove(key);
 			}
 		}
 		return null;
 	}
 
 	void put(RequestTag tag, DataChannelResponseHandler handler) {
-		synchronized (locker) {
-			table.put(tag.toString(), handler);
-		}
+		table.put(tag.toString(), handler);
 	}
 
 	Map<RequestTag, DataChannelResponseHandler> popAllHandlers() {
 		Map<RequestTag, DataChannelResponseHandler> returnTable = new HashMap<RequestTag, DataChannelResponseHandler>();
-		synchronized (locker) {
-			for (String key : table.keySet()) {
-				returnTable.put(new RequestTag(key), table.remove(key));
-			}
+		for (String key : table.keySet()) {
+			returnTable.put(new RequestTag(key), table.remove(key));
 		}
 		return returnTable;
 	}


### PR DESCRIPTION
複数スレッドで同一のDataChannelに対してリクエストを送信すると、レースコンディションによりデータロストが発生する恐れがある状態だった。そこで、複数スレッドからでも安全にDataChannelを使用できる形に改修する。