### PR TITLE
performance optimization: delete verbose lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+## Version 2.0.4
+性能改善 (不要な排他制御を排除)
+
 ## Version 2.0.3
 - マルチスレッド対応 
 - DataBusをVersion 2.1.0に更新

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ DataChannel の Android用の実装を提供します。
 ### gradle
 ```
 dependencies {
-	compile 'jp.co.dwango.cbb:data-channel:2.0.3'
+	compile 'jp.co.dwango.cbb:data-channel:2.0.4'
 }
 ```
 

--- a/data-channel/build.gradle
+++ b/data-channel/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.novoda.bintray-release'
-def pomVersion = "2.0.3"
+def pomVersion = "2.0.4"
 
 buildscript {
     repositories {

--- a/data-channel/src/main/java/jp/co/dwango/cbb/dc/DataChannelWaitingResponseTable.java
+++ b/data-channel/src/main/java/jp/co/dwango/cbb/dc/DataChannelWaitingResponseTable.java
@@ -8,33 +8,26 @@ import java.util.concurrent.ConcurrentHashMap;
 
 class DataChannelWaitingResponseTable {
 	private final Map<String, DataChannelResponseHandler> table = new ConcurrentHashMap<String, DataChannelResponseHandler>();
-	private final Object locker = new Object();
 
 	DataChannelResponseHandler get(RequestTag tag) {
-		synchronized (locker) {
-			Set<String> keys = table.keySet();
-			String tagString = tag.toString();
-			for (String key : keys) {
-				if (key.equals(tagString)) {
-					return table.remove(key);
-				}
+		Set<String> keys = table.keySet();
+		String tagString = tag.toString();
+		for (String key : keys) {
+			if (key.equals(tagString)) {
+				return table.remove(key);
 			}
 		}
 		return null;
 	}
 
 	void put(RequestTag tag, DataChannelResponseHandler handler) {
-		synchronized (locker) {
-			table.put(tag.toString(), handler);
-		}
+		table.put(tag.toString(), handler);
 	}
 
 	Map<RequestTag, DataChannelResponseHandler> popAllHandlers() {
 		Map<RequestTag, DataChannelResponseHandler> returnTable = new HashMap<RequestTag, DataChannelResponseHandler>();
-		synchronized (locker) {
-			for (String key : table.keySet()) {
-				returnTable.put(new RequestTag(key), table.remove(key));
-			}
+		for (String key : table.keySet()) {
+			returnTable.put(new RequestTag(key), table.remove(key));
 		}
 		return returnTable;
 	}


### PR DESCRIPTION
`DataChannel#latestTagNumber` のみ排他制御できていれば問題無いため, 不要な `synchronized` を排除する。