### PR TITLE
update data-bus-android to 2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+## Version 2.0.6
+- data-bus-androidを2.1.2に更新
+
 ## Version 2.0.5
 - 依存する Gradle のバージョンを更新
 - DataBusをVersion 2.1.1に更新

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ DataChannel の Android用の実装を提供します。
 ### gradle
 ```
 dependencies {
-	compile 'jp.co.dwango.cbb:data-channel:2.0.5'
+	compile 'jp.co.dwango.cbb:data-channel:2.0.6'
 }
 ```
 

--- a/data-channel/build.gradle
+++ b/data-channel/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.novoda.bintray-release'
-def pomVersion = "2.0.5"
+def pomVersion = "2.0.6"
 
 buildscript {
     repositories {
@@ -35,7 +35,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:23.2.1'
-    compile 'jp.co.dwango.cbb:data-bus:2.1.1'
+    compile 'jp.co.dwango.cbb:data-bus:2.1.2'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.9.5'
     testCompile 'org.json:json:20140107'


### PR DESCRIPTION
data-bus-android 2.1.2の取り込み
https://github.com/cross-border-bridge/data-bus-android/pull/9

- [x] data-bus-android 2.1.2 のpublish
- [x] data-bus-android2.1.2を取り込んでビルドが通る事の確認