### PR TITLE
update data-bus-android-to 2.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+## Version 2.0.7
+- data-bus-androidを2.1.3に更新
+
 ## Version 2.0.6
 - data-bus-androidを2.1.2に更新
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ DataChannel の Android用の実装を提供します。
 ### gradle
 ```
 dependencies {
-	compile 'jp.co.dwango.cbb:data-channel:2.0.6'
+	compile 'jp.co.dwango.cbb:data-channel:2.0.7'
 }
 ```
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion 26
     buildToolsVersion '25.0.0'
     defaultConfig {
         applicationId "jp.co.dwango.cbb.dc.test"
         minSdkVersion 16
-        targetSdkVersion 23
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -24,7 +24,7 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:23.2.1'
+    compile 'com.android.support:appcompat-v7:26.1.0'
     compile project(':data-channel')
     testCompile 'junit:junit:4.12'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,17 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:4.0.1'
     }
 }
 
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/data-channel/build.gradle
+++ b/data-channel/build.gradle
@@ -1,23 +1,26 @@
 apply plugin: 'com.android.library'
-apply plugin: 'com.novoda.bintray-release'
-def pomVersion = "2.0.6"
+apply plugin: 'com.jfrog.bintray'
+apply plugin: 'maven-publish'
+def libraryGroupId = 'jp.co.dwango.cbb'
+def libraryArtifactId = 'data-channel'
+def pomVersion = "2.0.7"
 
 buildscript {
     repositories {
         jcenter()
     }
     dependencies {
-        classpath 'com.novoda:bintray-release:0.4.0'
+        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4"
     }
 }
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion 26
     buildToolsVersion '25.0.0'
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 23
+        targetSdkVersion 26
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     compileOptions {
@@ -34,18 +37,52 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.2.1'
-    compile 'jp.co.dwango.cbb:data-bus:2.1.2'
+    compile 'com.android.support:appcompat-v7:26.1.0'
+    compile 'jp.co.dwango.cbb:data-bus:2.1.3'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.9.5'
     testCompile 'org.json:json:20140107'
 }
 
-publish {
-    userOrg = 'cross-border-bridge'
-    groupId = 'jp.co.dwango.cbb'
-    artifactId = 'data-channel'
-    publishVersion = pomVersion
-    desc = 'DataChannel for Android'
-    website = 'https://github.com/cross-border-bridge/data-channel-android'
+afterEvaluate {
+    publishing {
+        publications {
+            // Creates a Maven publication called "release".
+            release(MavenPublication) {
+                from components.release
+                groupId = libraryGroupId
+                artifactId = libraryArtifactId
+                version = pomVersion
+            }
+        }
+    }
+}
+
+bintray {
+    if (project.hasProperty('bintrayUser')) {
+        user = property('bintrayUser')
+    }
+    if (project.hasProperty('bintrayKey')) {
+        key = property('bintrayKey')
+    }
+    publications = ['release']
+    publish = true
+    if (project.hasProperty('dryRun')) {
+        dryRun = property('dryRun')
+    } else {
+        dryRun = false
+    }
+    override = true
+    pkg {
+        repo = 'maven'
+        name = libraryArtifactId
+        userOrg = 'cross-border-bridge'
+        desc = 'DataBus for Android'
+        websiteUrl = 'https://github.com/cross-border-bridge/data-channel-android'
+        publicDownloadNumbers = true
+        version {
+            name = pomVersion
+            released = new Date()
+        }
+    }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Mar 22 19:31:44 JST 2017
+#Mon Dec 14 12:04:31 JST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
- data-bus-android 2.1.3の取り込み
  - https://github.com/cross-border-bridge/data-bus-android/pull/10
- gradle-bintray-pluginへのreplace